### PR TITLE
Addition of times and locations of nearest and furthest strikes to statistics page

### DIFF
--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -443,8 +443,8 @@
 
 //Show location and times of nearest and furthest strokes, if known
 @define('BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES', False);
-@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT', True);
-@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT', True);
+@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT', False);
+@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT', False);
 
 
 /*******************************************************************/

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -1446,7 +1446,7 @@ define('BO_LOADAVG_TILES_STATIONS', 70);
 /*******************************************************************/
 /*** Settings for Developers                                     ***/
 
-@define('BO_DEBUG', true); //enables PHP error reporting
+@define('BO_DEBUG', false); //enables PHP error reporting
 @define('BO_LANG_AUTO_ADD', false); //automatically adds missing translations to the locale file if it is writeable
 
 

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -443,8 +443,8 @@
 
 //Show location and times of nearest and furthest strokes, if known
 @define('BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES', False);
-
-
+@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT', True);
+@define('BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT', True);
 
 
 /*******************************************************************/

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -441,6 +441,8 @@
 //Update "offline hours counter" only if station was online some time before (hours)
 @define('BO_STATISTICS_COUNT_OFFLINE_AFTER_MIN_ONLINE_HOURS', 96);
 
+//Collect and show location and times of nearest and furthest strokes
+@define('BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES', True);
 
 
 /*******************************************************************/
@@ -977,7 +979,7 @@
 @define('BO_GRAPH_RAW_H_STAT_SPEC', 150);
 
 
-//max. time in µs for displaying all graphs to a stroke
+//max. time in ï¿½s for displaying all graphs to a stroke
 @define('BO_GRAPH_RAW_MAX_TIME2', 350);
 
 //Colors
@@ -1405,7 +1407,7 @@ define('BO_LOADAVG_TILES_STATIONS', 70);
 @define('BO_TRIGGER_VOLTAGE', 0.45);
 
 //search interval for strike -> signal matching for foreign stations
-@define('BO_STR2SIG_INTERVAL_OTHERS', 8000); //µs
+@define('BO_STR2SIG_INTERVAL_OTHERS', 8000); //ï¿½s
 
 //needed for auto linking stations
 @define('BO_LINK_HOST', 'www.myblitzortung.org');

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -441,8 +441,10 @@
 //Update "offline hours counter" only if station was online some time before (hours)
 @define('BO_STATISTICS_COUNT_OFFLINE_AFTER_MIN_ONLINE_HOURS', 96);
 
-//Collect and show location and times of nearest and furthest strokes
-@define('BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES', True);
+//Show location and times of nearest and furthest strokes, if known
+@define('BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES', False);
+
+
 
 
 /*******************************************************************/
@@ -1444,7 +1446,7 @@ define('BO_LOADAVG_TILES_STATIONS', 70);
 /*******************************************************************/
 /*** Settings for Developers                                     ***/
 
-@define('BO_DEBUG', false); //enables PHP error reporting
+@define('BO_DEBUG', true); //enables PHP error reporting
 @define('BO_LANG_AUTO_ADD', false); //automatically adds missing translations to the locale file if it is writeable
 
 

--- a/includes/import.inc.php
+++ b/includes/import.inc.php
@@ -17,9 +17,10 @@ function bo_update_all($force = false, $only = '')
 	ini_set('default_socket_timeout', BO_SOCKET_TIMEOUT);
 
 	$debug = defined('BO_DEBUG') && BO_DEBUG;
+        
 	$max_time = bo_update_get_timeout();
 	bo_getset_timeout($max_time);
-
+        
 	//Check if sth. went wrong on the last update (if older continue)
 	$is_updating = (int)BoData::get('is_updating');
 	if ($is_updating && time() - $is_updating < min($max_time*5+60,$max_time+120) && !($force && $debug))
@@ -47,7 +48,7 @@ function bo_update_all($force = false, $only = '')
 
 	if (!BoData::get('first_update_time'))
         {
-                if ($debug) bo_echod("First update - forcing update of stations to allow statistics to run on first download");
+                bo_echod("First update - forcing update of stations to allow statistics to run on first download");
                 $stations_imported = bo_update_stations($force);
 		BoData::set('first_update_time', time());
         }
@@ -445,7 +446,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 				$D['ppos'] = ( floor( ($D['lat']+90) / BO_DB_PARTITION_LAT_DIVISOR) * (360 / BO_DB_PARTITION_LON_DIVISOR) + floor( ($D['lon']+180) / BO_DB_PARTITION_LON_DIVISOR) ) % 256;
 			}
 
-			
+                        
 			/********* Statistics **********/
 			foreach($statistic_stations as $stId)
 			{
@@ -464,8 +465,8 @@ function bo_update_strikes($force = false, $time_start_import = null)
                                 $max_dist_all_lat[$stId] = $D['lat'];    
                                 $max_dist_all_lon[$stId] = $D['lon'];                                           
                                 $max_dist_all[$stId] = $dist;
-                                $max_dist_all_time[$stId] = $D['time'];
-                                if ($debug) bo_echod("Found a new max in this import for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km lat : " . $max_dist_all_lat[$stId] . " lon : "  . $max_dist_all_lon[$stId] . " Time:" . $max_dist_all_time[$stId]);
+                                $max_dist_all_strike_time[$stId] = $D['time'];
+                                if ($debug === true) bo_echod("Found a new max in this import for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km lat : " . $max_dist_all_lat[$stId] . " lon : "  . $max_dist_all_lon[$stId] . " Time:" . $max_dist_all_strike_time[$stId]);
                                 }
                                 
 
@@ -474,8 +475,8 @@ function bo_update_strikes($force = false, $time_start_import = null)
                                 $min_dist_all_lat[$stId] = $D['lat'];    
                                 $min_dist_all_lon[$stId] = $D['lon'];                                            
                                 $min_dist_all[$stId] = $dist;
-                                $min_dist_all_time[$stId] = $D['time'];
-                                if ($debug) bo_echod("Found a new min in this import for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km lat : " . $min_dist_all_lat[$stId] . " lon : "  . $min_dist_all_lon[$stId] . ". Time:" . $min_dist_all_time[$stId]);
+                                $min_dist_all_strike_time[$stId] = $D['time'];
+                                if ($debug === true) bo_echod("Found a new min in this import for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km lat : " . $min_dist_all_lat[$stId] . " lon : "  . $min_dist_all_lon[$stId] . ". Time:" . $min_dist_all_strike_time[$stId]);
                                 }                                            
 				
 				$bear_data[$stId][$bear_id]++;
@@ -486,8 +487,30 @@ function bo_update_strikes($force = false, $time_start_import = null)
 				{
 					$bear_data_own[$stId][$bear_id]++;
 					$dist_data_own[$stId][$dist_id]++;
-					$max_dist_own[$stId] = max($dist, $max_dist_own[$stId]);
-					$min_dist_own[$stId] = min($dist, $min_dist_own[$stId]);
+					
+
+                                        
+                                        if ($dist>$max_dist_own[$stId])                 
+                                        {
+                                        $max_dist_own_lat[$stId] = $D['lat'];    
+                                        $max_dist_own_lon[$stId] = $D['lon'];                                           
+                                        $max_dist_own[$stId] = $dist;
+                                        $max_dist_own_strike_time[$stId] = $D['time'];
+                                        if ($debug) bo_echod("Found a new max in this import for strikes detected by this station at distance of " . $max_dist_own[$stId]/1000 . "km lat : " . $max_dist_own_lat[$stId] . " lon : "  . $max_dist_own_lon[$stId] . " Time:" . $max_dist_own_strike_time[$stId]);
+                                        }
+                                        
+                                        
+
+                                        if ($dist<$min_dist_own[$stId])
+                                        {
+                                        $min_dist_own_lat[$stId] = $D['lat'];    
+                                        $min_dist_own_lon[$stId] = $D['lon'];                                            
+                                        $min_dist_own[$stId] = $dist;
+                                        $min_dist_own_strike_time[$stId] = $D['time'];
+                                        if ($debug) bo_echod("Found a new min in this import for strikes detected by this station at a distance of " . $min_dist_all[$stId]/1000 . "km lat : " . $min_dist_own_lat[$stId] . " lon : "  . $min_dist_own_lon[$stId] . ". Time:" . $min_dist_own_strike_time[$stId]);
+                                        }                                            
+
+                                        
 					$strikesperstation[$stId]++;
 				}
 				
@@ -615,35 +638,40 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			BoData::set('longtime_dist_own'.$add, serialize($dist_data_tmp));
 
 			$max = BoData::get('longtime_max_dist_own'.$add);
-			if ($debug) bo_echod("Max own detected strike distance in database " . $max/1000 . "km. Max own detected strike distance from import " . $max_dist_own[$stId] / 1000 . " for station " .$stId );
+			if ($debug === true) bo_echod("Max own detected strike distance in database " . $max/1000 . "km. Max own detected strike distance from import " . $max_dist_own[$stId] / 1000 . " for station " .$stId );
 			if ($max < $max_dist_own[$stId])
 			{
 				BoData::set('longtime_max_dist_own'.$add, $max_dist_own[$stId]);
 				BoData::set('longtime_max_dist_own_time'.$add, time());
                                 BoData::set('longtime_max_dist_own_lat'.$add,$max_dist_own_lat[$stId]);      //storage for latitude
                                 BoData::set('longtime_max_dist_own_lon'.$add,$max_dist_own_lon[$stId]);      //storage for longtitude
-                                BoData::set('longtime_max_dist_own_time'.$add,$max_dist_own_time[$stId]);    //storage for time
-                                bo_echod("Recorded new max dist for strikes detected by station " . $stId . " at a distance of " . $max_dist_own[$stId]/1000 . "km lat:" . $max_dist_own_lat[$stId] . " lon: " . $max_dist_own_lon[$stId]);
+                                BoData::set('longtime_max_dist_own_strike_time'.$add,$max_dist_own_strike_time[$stId]);    //storage for time
+                                bo_echod("Recorded new max distance for strikes detected by station " . $stId . " at a distance of " . $max_dist_own[$stId]/1000 . "km lat:" . $max_dist_own_lat[$stId] . " lon: " . $max_dist_own_lon[$stId] . " Time:" . $max_dist_own_strike_time[$stId]);
 			}
                         else
                         {
-                                if ($debug) bo_echod("Did not record a new max dist for strikes detected by station ". $stId . " on this import");
-                        }
+                                if ($debug) bo_echod("Did not record a new max distance for strikes detected by station ". $stId . " on this import");
+                                
+                                
+                        }       
+                                
+                        
 
 			$min = BoData::get('longtime_min_dist_own'.$add);
-			if ($debug) bo_echod("Min detected strike distance in database " . $min/1000 . "km. Min own detected strike distance from import " . $min_dist_own[$stId] / 1000 . " for station " .$stId );
+			
 			if (!$min || $min > $min_dist_own[$stId])
 			{
 				BoData::set('longtime_min_dist_own'.$add, $min_dist_own[$stId]);
 				BoData::set('longtime_min_dist_own_time'.$add, time());
                                 BoData::set('longtime_min_dist_own_lat'.$add,$min_dist_own_lat[$stId]);      //storage for latitude
                                 BoData::set('longtime_min_dist_own_lon'.$add,$min_dist_own_lon[$stId]);      //storage for longtitude    
-                                BoData::set('longtime_min_dist_own_time'.$add,$min_dist_own_time[$stId]);    //storage for time
-                                bo_echod("Recorded new min dist for strikes detected by station " . $stId . " at a distance of " . $min_dist_own[$stId]/1000 . "km lat:" . $min_dist_own_lat[$stId] . " lon: " . $min_dist_own_lon[$stId]);
+                                BoData::set('longtime_min_dist_own_strike_time'.$add,$min_dist_own_strike_time[$stId]);    //storage for time
+                                bo_echod("Recorded new min distance for strikes detected by station " . $stId . " at a distance of " . $min_dist_own[$stId]/1000 . "km lat:" . $min_dist_own_lat[$stId] . " lon: " . $min_dist_own_lon[$stId] . " Time:" . $min_dist_own_strike_time[$stId]);
 			}
                         else
                         {
-                                if ($debug) bo_echod("Did not record a new min dist for strikes detected by station ". $stId . " on this import");
+                                if ($debug) bo_echod("Did not record a new min distance for strikes detected by station ". $stId . " on this import");
+                                
 		}
 		
 		}
@@ -677,41 +705,46 @@ function bo_update_strikes($force = false, $time_start_import = null)
 				}
 
 				$max = BoData::get('longtime_max_dist_all'.$add);
-				if ($debug) bo_echod("Max detected strike distance for network in database " . $max/1000 . "km. Max own detected strike distance from import " . $max_dist_all[$stId] / 1000 . " for station " .$stId );
+				
 				if ($max < $max_dist_all[$stId])
 				{
 					BoData::set('longtime_max_dist_all'.$add, $max_dist_all[$stId]);
 					BoData::set('longtime_max_dist_all_time'.$add, time());
 				        BoData::set('longtime_max_dist_all_lat'.$add,$max_dist_all_lat[$stId]);      //storage for latitude
                                         BoData::set('longtime_max_dist_all_lon'.$add,$max_dist_all_lon[$stId]);      //storage for longtitude 
-                                        BoData::set('longtime_max_dist_all_time'.$add,$max_dist_all_time[$stId]);    //storage for time
-                                        bo_echod("Recorded new longtime_max_dist_all at " . $max_dist_all_lat[$stId] . " " . $max_dist_all_lon[$stId] ." for station" .$stId  . ". A distance of " . $max_dist_all[$stId]/1000 ."km.  Time:" . $min_dist_all_time[$stId]);
+                                        BoData::set('longtime_max_dist_all_strike_time'.$add,$max_dist_all_strike_time[$stId]);    //storage for time
+                                        bo_echod("Recorded new max distance for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km. lat: " . $max_dist_all_lat[$stId] . " lon: " . $max_dist_all_lon[$stId] ." from station " .$stId . " Time:" . $max_dist_all_strike_time[$stId]);
                                         
 				}
                                 else
                                 {
-                                        if ($debug) bo_echod("Did not record a new max dist from station ". $stId . " on this import");
+                                        if ($debug) bo_echod("Did not record a new max distance from station ". $stId . " on this import");
+
                                 }    
 
 				$min = BoData::get('longtime_min_dist_all'.$add);
-                                if ($debug) bo_echod("Min detected strike distance for network in database " . $min/1000 . "km. Min own detected strike distance from import " . $min_dist_all[$stId] / 1000 . " for station " .$stId );
+                                
 				if (!$min || $min > $min_dist_all[$stId])
 				{
 					BoData::set('longtime_min_dist_all'.$add, $min_dist_all[$stId]);
 					BoData::set('longtime_min_dist_all_time'.$add, time());
                                         BoData::set('longtime_min_dist_all_lat'.$add,$min_dist_all_lat[$stId]);      //storage for latitude
                                         BoData::set('longtime_min_dist_all_lon'.$add,$min_dist_all_lon[$stId]);      //storage for longtitude    
-                                        BoData::set('longtime_min_dist_all_time'.$add,$min_dist_all_time[$stId]);    //storage for time
-                                        bo_echod("Recorded new longtime_min_dist_all at " . $min_dist_all_lat[$stId] . " " . $min_dist_all_lon[$stId] ." for station" .$stId .". A distance of " . $max_dist_all[$stId]/1000 ."km. Time:" . $min_dist_all_time[$stId]);
+                                        BoData::set('longtime_min_dist_all_strike_time'.$add,$min_dist_all_strike_time[$stId]);    //storage for time
+                                        bo_echod("Recorded new min distance for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km. lat: " . $min_dist_all_lat[$stId] . " lon: " . $min_dist_all_lon[$stId] ." from station " .$stId . " Time:" . $min_dist_all_strike_time[$stId]);
 				}
                                 else
                                 {
-                                        if ($debug) bo_echod("Did not record a new min dist from station ". $stId . " on this import");
+                                        if ($debug) bo_echod("Did not record a new min distance from station ". $stId . " on this import");
 			}
 			}
 
 		}
 
+                
+                
+                    
+                
 		BoDb::query("COMMIT", false);
 		BoDb::query("SET autocommit=1", false);
 		

--- a/includes/import.inc.php
+++ b/includes/import.inc.php
@@ -452,7 +452,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			{
 				$stLat = $stations[$stId]['lat'];
 				$stLon = $stations[$stId]['lon'];
-                                $debug = true;
+                             
 				if ($stLat == 0.0 && $stLon == 0.0) //station has no position yet
 					continue;
 
@@ -570,7 +570,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			{
 				$last_strike_time = $utime;
 				$timeout = true;
-				//break;
+				break;
 			}
 		}
 	
@@ -622,7 +622,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 		foreach($strikesperstation as $stId => $count)
 		{
 			$add = $stId == $own_id ? '' : '#'.$stId.'#';
-			$debug = true;
+			
 			BoData::update_add('count_strikes_own'.$add, $count);
 
 			$bear_data_tmp = unserialize(BoData::get('longtime_bear_own'.$add));
@@ -638,76 +638,77 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			BoData::set('longtime_dist_own'.$add, serialize($dist_data_tmp));
 
 			$max = BoData::get('longtime_max_dist_own'.$add);
-			if ($debug === true) bo_echod("Max own detected strike distance in database " . $max/1000 . "km. Max own detected strike distance from import " . $max_dist_own[$stId] / 1000 . " for station " .$stId );
-			if ($max < $max_dist_own[$stId])
-			{
-				BoData::set('longtime_max_dist_own'.$add, $max_dist_own[$stId]);
-				BoData::set('longtime_max_dist_own_time'.$add, time());
-                                BoData::set('longtime_max_dist_own_lat'.$add,$max_dist_own_lat[$stId]);      //storage for latitude
-                                BoData::set('longtime_max_dist_own_lon'.$add,$max_dist_own_lon[$stId]);      //storage for longtitude
-                                BoData::set('longtime_max_dist_own_strike_time'.$add,$max_dist_own_strike_time[$stId]);    //storage for time
-                                bo_echod("Recorded new max distance for strikes detected by station " . $stId . " at a distance of " . $max_dist_own[$stId]/1000 . "km lat:" . $max_dist_own_lat[$stId] . " lon: " . $max_dist_own_lon[$stId] . " Time:" . $max_dist_own_strike_time[$stId]);
-			}
-                        else
-                        {
-                                if ($debug) bo_echod("Did not record a new max distance for strikes detected by station ". $stId . " on this import");
-                                
-                                
-                        }       
-                                
-                        
-
-			$min = BoData::get('longtime_min_dist_own'.$add);
 			
-			if (!$min || $min > $min_dist_own[$stId])
-			{
-				BoData::set('longtime_min_dist_own'.$add, $min_dist_own[$stId]);
-				BoData::set('longtime_min_dist_own_time'.$add, time());
-                                BoData::set('longtime_min_dist_own_lat'.$add,$min_dist_own_lat[$stId]);      //storage for latitude
-                                BoData::set('longtime_min_dist_own_lon'.$add,$min_dist_own_lon[$stId]);      //storage for longtitude    
-                                BoData::set('longtime_min_dist_own_strike_time'.$add,$min_dist_own_strike_time[$stId]);    //storage for time
-                                bo_echod("Recorded new min distance for strikes detected by station " . $stId . " at a distance of " . $min_dist_own[$stId]/1000 . "km lat:" . $min_dist_own_lat[$stId] . " lon: " . $min_dist_own_lon[$stId] . " Time:" . $min_dist_own_strike_time[$stId]);
-			}
+			if ($max < $max_dist_own[$stId])
+                            {
+                            BoData::set('longtime_max_dist_own'.$add, $max_dist_own[$stId]);
+                            BoData::set('longtime_max_dist_own_time'.$add, time());
+                            BoData::set('longtime_max_dist_own_lat'.$add,$max_dist_own_lat[$stId]);      //storage for latitude
+                            BoData::set('longtime_max_dist_own_lon'.$add,$max_dist_own_lon[$stId]);      //storage for longtitude
+                            BoData::set('longtime_max_dist_own_strike_time'.$add,$max_dist_own_strike_time[$stId]);    //storage for time
+                            bo_echod("Recorded new max distance for strikes detected by station " . $stId . " at a distance of " . $max_dist_own[$stId]/1000 . "km lat:" . $max_dist_own_lat[$stId] . " lon: " . $max_dist_own_lon[$stId] . " Time:" . $max_dist_own_strike_time[$stId]);
+                            }
                         else
-                        {
-                                if ($debug) bo_echod("Did not record a new min distance for strikes detected by station ". $stId . " on this import");
+                            {
+                            if ($debug) bo_echod("Did not record a new max distance for strikes detected by station ". $stId . " on this import");
+                            if ($debug) bo_echod("Max dist own stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                            if (round(BoData::get('longtime_max_dist_own' . $add)/1000, 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon)/1000, 1)) 
+                                {
+                                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) 
+                                    {
+                                    bo_echod("Maximum distance own station inconsistency detected - overwriting maximum distance for station " . $stId . ".");
+                                    BoData::set('longtime_max_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon));
+                                    bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                    } 
+                                else 
+                                    {
+                                    bo_echod("Maximum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
+                                    }        
+                                }
+                            else
+                                {
+                                if ($debug) bo_echod("Maximum distance own - no inconsistency");
+                                }    
+                            }            
+                        
+                        $min = BoData::get('longtime_min_dist_own'.$add);
+			if (!$min || $min > $min_dist_own[$stId])
+                            {
+                            BoData::set('longtime_min_dist_own'.$add, $min_dist_own[$stId]);
+                            BoData::set('longtime_min_dist_own_time'.$add, time());
+                            BoData::set('longtime_min_dist_own_lat'.$add,$min_dist_own_lat[$stId]);      //storage for latitude
+                            BoData::set('longtime_min_dist_own_lon'.$add,$min_dist_own_lon[$stId]);      //storage for longtitude    
+                            BoData::set('longtime_min_dist_own_strike_time'.$add,$min_dist_own_strike_time[$stId]);    //storage for time
+                            bo_echod("Recorded new min distance for strikes detected by station " . $stId . " at a distance of " . $min_dist_own[$stId]/1000 . "km lat:" . $min_dist_own_lat[$stId] . " lon: " . $min_dist_own_lon[$stId] . " Time:" . $min_dist_own_strike_time[$stId]);
+                            }
+                        else
+                            {   
+                            if ($debug) bo_echod("Did not record a new min distance for strikes detected by station ". $stId . " on this import");
+                            if ($debug) bo_echod("Min dist own stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                            if (round(BoData::get('longtime_min_dist_own' . $add)/1000, 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon)/1000, 1)) 
+                                {
                                 
-                        }
-                        bo_echod("Checking for inconsistencies on statistics for own strike distances for station " . $stId);
+                                bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) 
+                                    {
+                                    bo_echod("Minimum distance own station inconsistency detected - overwriting minimum distance for station " . $stId . ".");
+                                    BoData::set('longtime_min_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon));
+                                    bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                    } 
+                                else 
+                                    {
+                                    bo_echod("Minimum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
+                                    }      
+                                }
+                            else
+                                {
+                                if ($debug) bo_echod("Minimum distance own - no inconsistency");
+                                }    
+                            }
 
-            if ($debug) {
-                bo_echod("Min dist own stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                bo_echod("Max dist own stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-            }
-
-            if (round(BoData::get('longtime_min_dist_own' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon), 1)) {
-                bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) {
-                    bo_echod("Minimum distance own station inconsistency detected - overwriting minimum distance for station " . $stId . ".");
-                    BoData::set('longtime_min_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon));
-                    bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                } else {
-                    bo_echod("Minimum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
+            
                 }
-            } else {
-                if ($debug)
-                    bo_echod("No inconsistency detected for minimum distance own station : " . $stId);
-            }
-
-            if (round(BoData::get('longtime_max_dist_own' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon), 1)) {
-                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
-                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) {
-                    bo_echod("Maximum distance own station inconsistency detected - overwriting maximum distance for station " . $stId . ".");
-                    BoData::set('longtime_max_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon));
-                    bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
-                } else {
-                    bo_echod("Maximum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
-                }
-            } else {
-                if ($debug)
-                    bo_echod("No inconsistency detected for maximum distance own station : " . $stId);
-            }
-        }
 
         //Update Longtime statistics per station for all strikes
 		foreach($statistic_stations as $stId)
@@ -739,85 +740,79 @@ function bo_update_strikes($force = false, $time_start_import = null)
 
 				$max = BoData::get('longtime_max_dist_all'.$add);
 				
-                if ($max < $max_dist_all[$stId]) 
-                {
-                    BoData::set('longtime_max_dist_all' . $add, $max_dist_all[$stId]);
-                    BoData::set('longtime_max_dist_all_time' . $add, time());
-                    BoData::set('longtime_max_dist_all_lat' . $add, $max_dist_all_lat[$stId]);                      //storage for latitude
-                    BoData::set('longtime_max_dist_all_lon' . $add, $max_dist_all_lon[$stId]);                      //storage for longtitude 
-                    BoData::set('longtime_max_dist_all_strike_time' . $add, $max_dist_all_strike_time[$stId]);      //storage for time
-                    bo_echod("Recorded new max distance for strikes detected by the network at a distance of " . $max_dist_all[$stId] / 1000 . "km. lat: " . $max_dist_all_lat[$stId] . " lon: " . $max_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $max_dist_all_strike_time[$stId]);
-                } 
-                else 
-                {
-                    if ($debug) bo_echod("Did not record a new max distance from station " . $stId . " on this import");
-                }
+                        if ($max < $max_dist_all[$stId]) 
+                            {   
+                            BoData::set('longtime_max_dist_all' . $add, $max_dist_all[$stId]);
+                            BoData::set('longtime_max_dist_all_time' . $add, time());
+                            BoData::set('longtime_max_dist_all_lat' . $add, $max_dist_all_lat[$stId]);                      //storage for latitude
+                            BoData::set('longtime_max_dist_all_lon' . $add, $max_dist_all_lon[$stId]);                      //storage for longtitude 
+                            BoData::set('longtime_max_dist_all_strike_time' . $add, $max_dist_all_strike_time[$stId]);      //storage for time
+                            bo_echod("Recorded new max distance for strikes detected by the network at a distance of " . $max_dist_all[$stId] / 1000 . "km. lat: " . $max_dist_all_lat[$stId] . " lon: " . $max_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $max_dist_all_strike_time[$stId]);
+                            } 
+                        else 
+                            {
+                            if ($debug) bo_echod("Did not record a new max distance from station " . $stId . " on this import");
+                            if ($debug) bo_echod("Max dist all stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                            if ((round(BoData::get('longtime_max_dist_all' . $add)/1000, 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon)/1000, 1)) && $stLat != Null & $stLon != Null)
+                                {
+                                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT == True) 
+                                    {
+                                    bo_echod("Maximum distance all station inconsistency detected - overwriting maximum distance for station " . $stId . ". Station lat:" . $stLat . " lon:" . $stLon);
+                                    BoData::set('longtime_max_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon));
+                                    bo_echod("Max dist stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                    } 
+                                else 
+                                    {
+                                    bo_echod("Maximum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
+                                    }        
+                                }
+                            else
+                                {
+                                if ($debug) bo_echod("Maximum distance all - no inconsistency");
+                                }
+                            }
 
-                $min = BoData::get('longtime_min_dist_all' . $add);
-
-                if (!$min || $min > $min_dist_all[$stId]) {
-                    BoData::set('longtime_min_dist_all' . $add, $min_dist_all[$stId]);
-                    BoData::set('longtime_min_dist_all_time' . $add, time());
-                    BoData::set('longtime_min_dist_all_lat' . $add, $min_dist_all_lat[$stId]);                      //storage for latitude
-                    BoData::set('longtime_min_dist_all_lon' . $add, $min_dist_all_lon[$stId]);                      //storage for longtitude    
-                    BoData::set('longtime_min_dist_all_strike_time' . $add, $min_dist_all_strike_time[$stId]);      //storage for time
-                    bo_echod("Recorded new min distance for strikes detected by the network at a distance of " . $min_dist_all[$stId] / 1000 . "km. lat: " . $min_dist_all_lat[$stId] . " lon: " . $min_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $min_dist_all_strike_time[$stId]);
-                } else {
-                    if ($debug) bo_echod("Did not record a new min distance from station " . $stId . " on this import");
-                }
+                        $min = BoData::get('longtime_min_dist_all' . $add);
+                        if (!$min || $min > $min_dist_all[$stId]) 
+                            {
+                            BoData::set('longtime_min_dist_all' . $add, $min_dist_all[$stId]);
+                            BoData::set('longtime_min_dist_all_time' . $add, time());
+                            BoData::set('longtime_min_dist_all_lat' . $add, $min_dist_all_lat[$stId]);                      //storage for latitude
+                            BoData::set('longtime_min_dist_all_lon' . $add, $min_dist_all_lon[$stId]);                      //storage for longtitude    
+                            BoData::set('longtime_min_dist_all_strike_time' . $add, $min_dist_all_strike_time[$stId]);      //storage for time
+                            bo_echod("Recorded new min distance for strikes detected by the network at a distance of " . $min_dist_all[$stId] / 1000 . "km. lat: " . $min_dist_all_lat[$stId] . " lon: " . $min_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $min_dist_all_strike_time[$stId]);
+                            } 
+                        else 
+                            {
+                            if ($debug) bo_echod("Did not record a new min distance from station " . $stId . " on this import");
+                            if ($debug) bo_echod("Min dist all stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                            if ((round(BoData::get('longtime_min_dist_all' . $add)/1000, 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon)/1000, 1)) && $stLat != Null & $stLon != Null)
+                                {
+                                bo_echod("Min dist stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT == True) 
+                                    {
+                                    bo_echod("Minimum distance all station inconsistency detected - overwriting minimum distance for station " . $stId . ". Station lat:" . $stLat . " lon:" . $stLon);
+                                    BoData::set('longtime_min_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon));
+                                    bo_echod("Min dist stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                                    } 
+                                else 
+                                    {
+                                    bo_echod("Minimum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
+                                    }        
+                                }
+                            else
+                                {
+                                if ($debug) bo_echod("Minimum distance all - no inconsistency");
+                                }
+                            }
 
             
-            }
+                        }
 
 
-            bo_echod("Checking for inconsistencies on statistics for network all strike distances for station :" . $stId);
-           
-            if ($debug) {
-                bo_echod("Min dist all stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                bo_echod("Max dist all stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-            }
-
-            if (round(BoData::get('longtime_min_dist_all' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon), 1)) 
-                {
-          
-                bo_echod("Minimum distance stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Minimum distance calculated " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                bo_echod("Minimum distance stored lat :" . BoData::get('longtime_min_dist_all_lat' . $add) . " . lon : " . BoData::get('longtime_min_dist_all_lon' . $add)) ;
             
-                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT == True) {
-                    bo_echod("Minimum distance all station inconsistency detected - overwriting minimum distance for station " . $stId . ".");
-                    BoData::set('longtime_min_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon));
-                    bo_echod("Minimum distance stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Minimum distance calculated " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                } 
-                else 
-                {
-                    bo_echod("Minimum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
                 }
-            } 
-            else 
-            {
-                if ($debug) bo_echod("No inconsistency detected for minimum distance all station : " . $stId);
-            }
-
-            if (round(BoData::get('longtime_max_dist_all' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon), 1)) {
-                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-
-
-                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) 
-                {
-                    bo_echod("Maximum distance all station inconsistency detected - overwriting maximum distance for station " . $stId . ".");
-                    BoData::set('longtime_max_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon));
-                    bo_echod("Maximum distance stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Maximum distance calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
-                } 
-                else 
-                {
-                    bo_echod("Maximum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
-                }
-            } 
-            else 
-            {
-            if ($debug) bo_echod("No inconsistency detected for maximum distance all station : " . $stId);
-            }
-        }
 
 
 

--- a/includes/import.inc.php
+++ b/includes/import.inc.php
@@ -42,7 +42,7 @@ function bo_update_all($force = false, $only = '')
 		$max_sleep = BO_UP_MAX_SLEEP;
 		$sleep = rand(0,$max_sleep);
 		bo_echod("Waiting $sleep seconds, to avoid too high load on Blitzortung servers ...");
-		sleep($sleep);
+		//sleep($sleep);
 	}
 
 
@@ -452,7 +452,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			{
 				$stLat = $stations[$stId]['lat'];
 				$stLon = $stations[$stId]['lon'];
-
+                                $debug = true;
 				if ($stLat == 0.0 && $stLon == 0.0) //station has no position yet
 					continue;
 
@@ -466,7 +466,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
                                 $max_dist_all_lon[$stId] = $D['lon'];                                           
                                 $max_dist_all[$stId] = $dist;
                                 $max_dist_all_strike_time[$stId] = $D['time'];
-                                if ($debug === true) bo_echod("Found a new max in this import for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km lat : " . $max_dist_all_lat[$stId] . " lon : "  . $max_dist_all_lon[$stId] . " Time:" . $max_dist_all_strike_time[$stId]);
+                                if ($debug) bo_echod("Found a new max in this import for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km lat : " . $max_dist_all_lat[$stId] . " lon : "  . $max_dist_all_lon[$stId] . " Time:" . $max_dist_all_strike_time[$stId]);
                                 }
                                 
 
@@ -476,7 +476,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
                                 $min_dist_all_lon[$stId] = $D['lon'];                                            
                                 $min_dist_all[$stId] = $dist;
                                 $min_dist_all_strike_time[$stId] = $D['time'];
-                                if ($debug === true) bo_echod("Found a new min in this import for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km lat : " . $min_dist_all_lat[$stId] . " lon : "  . $min_dist_all_lon[$stId] . ". Time:" . $min_dist_all_strike_time[$stId]);
+                                if ($debug) bo_echod("Found a new min in this import for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km lat : " . $min_dist_all_lat[$stId] . " lon : "  . $min_dist_all_lon[$stId] . ". Time:" . $min_dist_all_strike_time[$stId]);
                                 }                                            
 				
 				$bear_data[$stId][$bear_id]++;
@@ -570,7 +570,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			{
 				$last_strike_time = $utime;
 				$timeout = true;
-				break;
+				//break;
 			}
 		}
 	
@@ -622,7 +622,7 @@ function bo_update_strikes($force = false, $time_start_import = null)
 		foreach($strikesperstation as $stId => $count)
 		{
 			$add = $stId == $own_id ? '' : '#'.$stId.'#';
-			
+			$debug = true;
 			BoData::update_add('count_strikes_own'.$add, $count);
 
 			$bear_data_tmp = unserialize(BoData::get('longtime_bear_own'.$add));
@@ -672,11 +672,44 @@ function bo_update_strikes($force = false, $time_start_import = null)
                         {
                                 if ($debug) bo_echod("Did not record a new min distance for strikes detected by station ". $stId . " on this import");
                                 
-		}
-		
-		}
+                        }
+                        bo_echod("Checking for inconsistencies on statistics for own strike distances for station " . $stId);
 
-		//Update Longtime statistics per station for all strikes
+            if ($debug) {
+                bo_echod("Min dist own stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                bo_echod("Max dist own stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+            }
+
+            if (round(BoData::get('longtime_min_dist_own' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon), 1)) {
+                bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) {
+                    bo_echod("Minimum distance own station inconsistency detected - overwriting minimum distance for station " . $stId . ".");
+                    BoData::set('longtime_min_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon));
+                    bo_echod("Min dist stored " . BoData::get('longtime_min_dist_own' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                } else {
+                    bo_echod("Minimum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
+                }
+            } else {
+                if ($debug)
+                    bo_echod("No inconsistency detected for minimum distance own station : " . $stId);
+            }
+
+            if (round(BoData::get('longtime_max_dist_own' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon), 1)) {
+                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) {
+                    bo_echod("Maximum distance own station inconsistency detected - overwriting maximum distance for station " . $stId . ".");
+                    BoData::set('longtime_max_dist_own' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon));
+                    bo_echod("Max dist stored " . BoData::get('longtime_max_dist_own' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_own_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $add . ".");
+                } else {
+                    bo_echod("Maximum distance own station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT is not True");
+                }
+            } else {
+                if ($debug)
+                    bo_echod("No inconsistency detected for maximum distance own station : " . $stId);
+            }
+        }
+
+        //Update Longtime statistics per station for all strikes
 		foreach($statistic_stations as $stId)
 		{
 			//update only if station is active or got some strikes during the update
@@ -706,46 +739,91 @@ function bo_update_strikes($force = false, $time_start_import = null)
 
 				$max = BoData::get('longtime_max_dist_all'.$add);
 				
-				if ($max < $max_dist_all[$stId])
-				{
-					BoData::set('longtime_max_dist_all'.$add, $max_dist_all[$stId]);
-					BoData::set('longtime_max_dist_all_time'.$add, time());
-				        BoData::set('longtime_max_dist_all_lat'.$add,$max_dist_all_lat[$stId]);      //storage for latitude
-                                        BoData::set('longtime_max_dist_all_lon'.$add,$max_dist_all_lon[$stId]);      //storage for longtitude 
-                                        BoData::set('longtime_max_dist_all_strike_time'.$add,$max_dist_all_strike_time[$stId]);    //storage for time
-                                        bo_echod("Recorded new max distance for strikes detected by the network at a distance of " . $max_dist_all[$stId]/1000 . "km. lat: " . $max_dist_all_lat[$stId] . " lon: " . $max_dist_all_lon[$stId] ." from station " .$stId . " Time:" . $max_dist_all_strike_time[$stId]);
-                                        
-				}
-                                else
-                                {
-                                        if ($debug) bo_echod("Did not record a new max distance from station ". $stId . " on this import");
+                if ($max < $max_dist_all[$stId]) 
+                {
+                    BoData::set('longtime_max_dist_all' . $add, $max_dist_all[$stId]);
+                    BoData::set('longtime_max_dist_all_time' . $add, time());
+                    BoData::set('longtime_max_dist_all_lat' . $add, $max_dist_all_lat[$stId]);                      //storage for latitude
+                    BoData::set('longtime_max_dist_all_lon' . $add, $max_dist_all_lon[$stId]);                      //storage for longtitude 
+                    BoData::set('longtime_max_dist_all_strike_time' . $add, $max_dist_all_strike_time[$stId]);      //storage for time
+                    bo_echod("Recorded new max distance for strikes detected by the network at a distance of " . $max_dist_all[$stId] / 1000 . "km. lat: " . $max_dist_all_lat[$stId] . " lon: " . $max_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $max_dist_all_strike_time[$stId]);
+                } 
+                else 
+                {
+                    if ($debug) bo_echod("Did not record a new max distance from station " . $stId . " on this import");
+                }
 
-                                }    
+                $min = BoData::get('longtime_min_dist_all' . $add);
 
-				$min = BoData::get('longtime_min_dist_all'.$add);
-                                
-				if (!$min || $min > $min_dist_all[$stId])
-				{
-					BoData::set('longtime_min_dist_all'.$add, $min_dist_all[$stId]);
-					BoData::set('longtime_min_dist_all_time'.$add, time());
-                                        BoData::set('longtime_min_dist_all_lat'.$add,$min_dist_all_lat[$stId]);      //storage for latitude
-                                        BoData::set('longtime_min_dist_all_lon'.$add,$min_dist_all_lon[$stId]);      //storage for longtitude    
-                                        BoData::set('longtime_min_dist_all_strike_time'.$add,$min_dist_all_strike_time[$stId]);    //storage for time
-                                        bo_echod("Recorded new min distance for strikes detected by the network at a distance of " . $min_dist_all[$stId]/1000 . "km. lat: " . $min_dist_all_lat[$stId] . " lon: " . $min_dist_all_lon[$stId] ." from station " .$stId . " Time:" . $min_dist_all_strike_time[$stId]);
-				}
-                                else
-                                {
-                                        if ($debug) bo_echod("Did not record a new min distance from station ". $stId . " on this import");
-			}
-			}
+                if (!$min || $min > $min_dist_all[$stId]) {
+                    BoData::set('longtime_min_dist_all' . $add, $min_dist_all[$stId]);
+                    BoData::set('longtime_min_dist_all_time' . $add, time());
+                    BoData::set('longtime_min_dist_all_lat' . $add, $min_dist_all_lat[$stId]);                      //storage for latitude
+                    BoData::set('longtime_min_dist_all_lon' . $add, $min_dist_all_lon[$stId]);                      //storage for longtitude    
+                    BoData::set('longtime_min_dist_all_strike_time' . $add, $min_dist_all_strike_time[$stId]);      //storage for time
+                    bo_echod("Recorded new min distance for strikes detected by the network at a distance of " . $min_dist_all[$stId] / 1000 . "km. lat: " . $min_dist_all_lat[$stId] . " lon: " . $min_dist_all_lon[$stId] . " from station " . $stId . " Time:" . $min_dist_all_strike_time[$stId]);
+                } else {
+                    if ($debug) bo_echod("Did not record a new min distance from station " . $stId . " on this import");
+                }
 
-		}
+            
+            }
 
-                
-                
-                    
-                
-		BoDb::query("COMMIT", false);
+
+            bo_echod("Checking for inconsistencies on statistics for network all strike distances for station :" . $stId);
+           
+            if ($debug) {
+                bo_echod("Min dist all stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Min dist calculate " . bo_latlon2dist(BoData::get('longtime_min_dist_own_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                bo_echod("Max dist all stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_own_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+            }
+
+            if (round(BoData::get('longtime_min_dist_all' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon), 1)) 
+                {
+          
+                bo_echod("Minimum distance stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Minimum distance calculated " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                bo_echod("Minimum distance stored lat :" . BoData::get('longtime_min_dist_all_lat' . $add) . " . lon : " . BoData::get('longtime_min_dist_all_lon' . $add)) ;
+            
+                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT == True) {
+                    bo_echod("Minimum distance all station inconsistency detected - overwriting minimum distance for station " . $stId . ".");
+                    BoData::set('longtime_min_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon));
+                    bo_echod("Minimum distance stored " . BoData::get('longtime_min_dist_all' . $add) / 1000 . "km. Minimum distance calculated " . bo_latlon2dist(BoData::get('longtime_min_dist_all_lat' . $add), BoData::get('longtime_min_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                } 
+                else 
+                {
+                    bo_echod("Minimum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
+                }
+            } 
+            else 
+            {
+                if ($debug) bo_echod("No inconsistency detected for minimum distance all station : " . $stId);
+            }
+
+            if (round(BoData::get('longtime_max_dist_all' . $add), 1) != round(bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon), 1)) {
+                bo_echod("Max dist stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Max dist calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+
+
+                if (BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_OWN_IF_DATA_INCONSISTENT == True) 
+                {
+                    bo_echod("Maximum distance all station inconsistency detected - overwriting maximum distance for station " . $stId . ".");
+                    BoData::set('longtime_max_dist_all' . $add, bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon));
+                    bo_echod("Maximum distance stored " . BoData::get('longtime_max_dist_all' . $add) / 1000 . "km. Maximum distance calculate " . bo_latlon2dist(BoData::get('longtime_max_dist_all_lat' . $add), BoData::get('longtime_max_dist_all_lon' . $add), $stLat, $stLon) / 1000 . "km. for station " . $stId . ".");
+                } 
+                else 
+                {
+                    bo_echod("Maximum distance all station inconsistency detected - taking no action for station " . $stId . " as BO_STATISTICS_OVERWRITE_MIN_MAX_DISTANCES_FOR_ALL_IF_DATA_INCONSISTENT is not True");
+                }
+            } 
+            else 
+            {
+            if ($debug) bo_echod("No inconsistency detected for maximum distance all station : " . $stId);
+            }
+        }
+
+
+
+
+
+        BoDb::query("COMMIT", false);
 		BoDb::query("SET autocommit=1", false);
 		
 		if ($timeout)

--- a/includes/import.inc.php
+++ b/includes/import.inc.php
@@ -341,7 +341,8 @@ function bo_update_strikes($force = false, $time_start_import = null)
 			}
 			
 			$D['time_ns'] = substr($l, 20, 9);
-			
+                        if (strpos($D['time_ns'],"-") != false) { bo_echod($D['time_ns']." $l"); $error++; continue; } // to catch an error in  http://data.blitzortung.org/Data_2/Protected/Strokes/2018/11/05/14/ line 144
+
 			//check if strike is already imported
 			if ($utime == $strike_last_time && $D['time_ns'] == $strike_last_time_ns)
 			{

--- a/includes/import.inc.php
+++ b/includes/import.inc.php
@@ -42,7 +42,7 @@ function bo_update_all($force = false, $only = '')
 		$max_sleep = BO_UP_MAX_SLEEP;
 		$sleep = rand(0,$max_sleep);
 		bo_echod("Waiting $sleep seconds, to avoid too high load on Blitzortung servers ...");
-		//sleep($sleep);
+		sleep($sleep);
 	}
 
 

--- a/includes/statistics.inc.php
+++ b/includes/statistics.inc.php
@@ -1526,7 +1526,13 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	$active_days 		  = BoData::get('longtime_station_active_time'.$add) / 3600 / 24;
 	$inactive_days 		  = BoData::get('longtime_station_inactive_time'.$add) / 3600 / 24;
 	$min_dist_own 		  = BoData::get('longtime_min_dist_own'.$add) / 1000;
+        $min_dist_own_lat 	  = BoData::get('longtime_min_dist_own_lat'.$add);
+        $min_dist_own_lon         = BoData::get('longtime_min_dist_own_lon'.$add);
+        $min_dist_own_time        = BoData::get('longtime_min_dist_own_time'.$add);
 	$max_dist_own 		  = BoData::get('longtime_max_dist_own'.$add) / 1000;
+        $max_dist_own_lat 	  = BoData::get('longtime_max_dist_own_lat'.$add);
+        $max_dist_own_lon         = BoData::get('longtime_max_dist_own_lon'.$add);
+        $max_dist_own_time        = BoData::get('longtime_max_dist_own_time'.$add);
 	$max_str_own 		  = (double)BoData::get('longtime_max_strikesh_own'.$add);
 	$max_sig_own 		  = (double)BoData::get('longtime_max_signalsh_own'.$add);
 	$first_update_station = BoData::get('longtime_station_first_time'.$add);
@@ -1536,7 +1542,13 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	//Global
 	$strikes	  		= BoData::get('count_strikes'.$add);
 	$min_dist_all 		= BoData::get('longtime_min_dist_all'.$add) / 1000;
+        $min_dist_all_lat       = BoData::get('longtime_min_dist_all_lat'.$add);
+        $min_dist_all_lon       = BoData::get('longtime_min_dist_all_lon'.$add);               
+        $min_dist_all_time      = BoData::get('longtime_min_dist_all_time'.$add);               
 	$max_dist_all 		= BoData::get('longtime_max_dist_all'.$add) / 1000;
+        $max_dist_all_lat       = BoData::get('longtime_max_dist_all_lat'.$add);
+        $max_dist_all_lon       = BoData::get('longtime_max_dist_all_lon'.$add);
+        $max_dist_all_time      = BoData::get('longtime_max_dist_all_time'.$add);               
 	$max_str_all 		= (double)BoData::get('longtime_max_strikesh');
 	$max_sig_all 		= (double)BoData::get('longtime_max_signalsh');
 	$max_active 		= (double)BoData::get('longtime_count_max_active_stations');
@@ -1626,7 +1638,24 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 		}
 
 		echo '<li><span class="bo_descr">'._BL('Min dist').': </span><span class="bo_value">'._BK($min_dist_own, 1).'</span>';
+		
+                
+                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+                {
+                echo '<li><span class="bo_descr">'._BL('At').
+             ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_own_lat  .','. $min_dist_own_lon .
+             ' " target="_blank" ><span class="bo_value">'._BN($min_dist_own_lat,3).'&deg; / '._BN($min_dist_own_lon,3).
+             '&deg</span> </span><span class="bo_value">(' . ($min_dist_own_time).')</span></a>';
+                }
 		echo '<li><span class="bo_descr">'._BL('Max dist').': </span><span class="bo_value">'._BK($max_dist_own, 1).'</span>';
+	
+                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+                {
+                echo '<li><span class="bo_descr">'._BL('At').
+             ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_own_lat  .','. $max_dist_own_lon .
+             ' " target="_blank" ><span class="bo_value">'._BN($max_dist_own_lat,3).'&deg; / '._BN($max_dist_own_lon,3).
+             '&deg</span> </span><span class="bo_value">(' . ($max_dist_own_time).')</span></a>';
+                }
 		echo '<li><span class="bo_descr">'._BL('Signals detected').': </span><span class="bo_value">'._BN($signals, 0).'</span>';
 		echo '<li><span class="bo_descr">'._BL('Strike ratio').': </span><span class="bo_value">'.$strike_ratio.'</span>';
 		echo '<li><span class="bo_descr">'._BL('Signal ratio').': </span><span class="bo_value">'.$signal_ratio.'</span>';
@@ -1649,8 +1678,26 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	if ($station_id)
 	{
 		echo '<li><span class="bo_descr">'._BL('Min dist').': </span><span class="bo_value">'._BK($min_dist_all, 1).'</span>';
+        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+        {
+        echo '<li><span class="bo_descr">'._BL('At').
+             ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_all_lat  .','. $min_dist_all_lon .
+             ' " target="_blank" ><span class="bo_value">'._BN($min_dist_all_lat,3).'&deg; / '._BN($min_dist_all_lon,3).
+             '&deg</span> </span><span class="bo_value">(' . ($min_dist_all_time).')</span></a>';
+        }
 		echo '<li><span class="bo_descr">'._BL('Max dist').': </span><span class="bo_value">'._BK($max_dist_all, 1).'</span>';
+        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+        {        
+        echo '<li><span class="bo_descr">'._BL('At').
+             ': </span><a href = "http://maps.google.com/?q= ' . $max_dist_all_lat  .','. $max_dist_all_lon .
+             ' " target="_blank" ><span class="bo_value">'._BN($max_dist_all_lat,3).'&deg; / '._BN($max_dist_all_lon,3).
+             '&deg</span> </span><span class="bo_value">(' . ($max_dist_all_time).')</span></a>';
 	}
+		
+
+        
+        
+        }
 		
 	echo '<li><span class="bo_descr">'._BL('Max signals per hour').': </span><span class="bo_value">'._BN($max_sig_all, 0).'</span>';
 	echo '<li><span class="bo_descr">'._BL('Max participants per strike').': </span><span class="bo_value">'._BN($max_part, 0).'</span>';

--- a/includes/statistics.inc.php
+++ b/includes/statistics.inc.php
@@ -1528,11 +1528,11 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	$min_dist_own 		  = BoData::get('longtime_min_dist_own'.$add) / 1000;
         $min_dist_own_lat 	  = BoData::get('longtime_min_dist_own_lat'.$add);
         $min_dist_own_lon         = BoData::get('longtime_min_dist_own_lon'.$add);
-        $min_dist_own_time        = BoData::get('longtime_min_dist_own_time'.$add);
+        $min_dist_own_strike_time = BoData::get('longtime_min_dist_own_strike_time'.$add);
 	$max_dist_own 		  = BoData::get('longtime_max_dist_own'.$add) / 1000;
         $max_dist_own_lat 	  = BoData::get('longtime_max_dist_own_lat'.$add);
         $max_dist_own_lon         = BoData::get('longtime_max_dist_own_lon'.$add);
-        $max_dist_own_time        = BoData::get('longtime_max_dist_own_time'.$add);
+        $max_dist_own_strike_time = BoData::get('longtime_max_dist_own_strike_time'.$add);
 	$max_str_own 		  = (double)BoData::get('longtime_max_strikesh_own'.$add);
 	$max_sig_own 		  = (double)BoData::get('longtime_max_signalsh_own'.$add);
 	$first_update_station = BoData::get('longtime_station_first_time'.$add);
@@ -1544,11 +1544,11 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	$min_dist_all 		= BoData::get('longtime_min_dist_all'.$add) / 1000;
         $min_dist_all_lat       = BoData::get('longtime_min_dist_all_lat'.$add);
         $min_dist_all_lon       = BoData::get('longtime_min_dist_all_lon'.$add);               
-        $min_dist_all_time      = BoData::get('longtime_min_dist_all_time'.$add);               
+        $min_dist_all_strike_time = BoData::get('longtime_min_dist_all_strike_time'.$add);               
 	$max_dist_all 		= BoData::get('longtime_max_dist_all'.$add) / 1000;
         $max_dist_all_lat       = BoData::get('longtime_max_dist_all_lat'.$add);
         $max_dist_all_lon       = BoData::get('longtime_max_dist_all_lon'.$add);
-        $max_dist_all_time      = BoData::get('longtime_max_dist_all_time'.$add);               
+        $max_dist_all_strike_time      = BoData::get('longtime_max_dist_all_strike_time'.$add);               
 	$max_str_all 		= (double)BoData::get('longtime_max_strikesh');
 	$max_sig_all 		= (double)BoData::get('longtime_max_signalsh');
 	$max_active 		= (double)BoData::get('longtime_count_max_active_stations');
@@ -1640,21 +1640,21 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 		echo '<li><span class="bo_descr">'._BL('Min dist').': </span><span class="bo_value">'._BK($min_dist_own, 1).'</span>';
 		
                 
-                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True && $min_dist_own_lat != Null  && $min_dist_own_lon != Null)
                 {
-                echo '<li><span class="bo_descr">'._BL('At').
+                echo '<li><span class="bo_descr">'._BL('Lat / Lon (Time)').
              ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_own_lat  .','. $min_dist_own_lon .
              ' " target="_blank" ><span class="bo_value">'._BN($min_dist_own_lat,3).'&deg; / '._BN($min_dist_own_lon,3).
-             '&deg</span> </span><span class="bo_value">(' . ($min_dist_own_time).')</span></a>';
+             '&deg</span> </span><span class="bo_value">(' . ($min_dist_own_strike_time).')</span></a>';
                 }
 		echo '<li><span class="bo_descr">'._BL('Max dist').': </span><span class="bo_value">'._BK($max_dist_own, 1).'</span>';
 	
-                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+                if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True && $max_dist_own_lat != Null  && $max_dist_own_lon != Null)
                 {
-                echo '<li><span class="bo_descr">'._BL('At').
+                echo '<li><span class="bo_descr">'._BL('Lat / Lon (Time)').
              ': </span><a href = "http://maps.google.com/?q= ' . $max_dist_own_lat  .','. $max_dist_own_lon .
              ' " target="_blank" ><span class="bo_value">'._BN($max_dist_own_lat,3).'&deg; / '._BN($max_dist_own_lon,3).
-             '&deg</span> </span><span class="bo_value">(' . ($max_dist_own_time).')</span></a>';
+             '&deg</span> </span><span class="bo_value">(' . ($max_dist_own_strike_time).')</span></a>';
                 }
 		echo '<li><span class="bo_descr">'._BL('Signals detected').': </span><span class="bo_value">'._BN($signals, 0).'</span>';
 		echo '<li><span class="bo_descr">'._BL('Strike ratio').': </span><span class="bo_value">'.$strike_ratio.'</span>';
@@ -1678,20 +1678,20 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
 	if ($station_id)
 	{
 		echo '<li><span class="bo_descr">'._BL('Min dist').': </span><span class="bo_value">'._BK($min_dist_all, 1).'</span>';
-        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True && $min_dist_all_lat != Null  && $min_dist_all_lon != Null)
         {
-        echo '<li><span class="bo_descr">'._BL('At').
+        echo '<li><span class="bo_descr">'._BL('Lat / Lon (Time)').
              ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_all_lat  .','. $min_dist_all_lon .
              ' " target="_blank" ><span class="bo_value">'._BN($min_dist_all_lat,3).'&deg; / '._BN($min_dist_all_lon,3).
-             '&deg</span> </span><span class="bo_value">(' . ($min_dist_all_time).')</span></a>';
+             '&deg</span> </span><span class="bo_value">(' . ($min_dist_all_strike_time).')</span></a>';
         }
 		echo '<li><span class="bo_descr">'._BL('Max dist').': </span><span class="bo_value">'._BK($max_dist_all, 1).'</span>';
-        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
+        if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True && $max_dist_all_lat != Null  && $max_dist_all_lon != Null)
         {        
-        echo '<li><span class="bo_descr">'._BL('At').
+        echo '<li><span class="bo_descr">'._BL('Lat / Lon (Time)').
              ': </span><a href = "http://maps.google.com/?q= ' . $max_dist_all_lat  .','. $max_dist_all_lon .
              ' " target="_blank" ><span class="bo_value">'._BN($max_dist_all_lat,3).'&deg; / '._BN($max_dist_all_lon,3).
-             '&deg</span> </span><span class="bo_value">(' . ($max_dist_all_time).')</span></a>';
+             '&deg</span> </span><span class="bo_value">(' . ($max_dist_all_strike_time).')</span></a>';
 	}
 		
 

--- a/includes/statistics.inc.php
+++ b/includes/statistics.inc.php
@@ -1652,7 +1652,7 @@ function bo_show_statistics_longtime($station_id = 0, $own_station = true, $add_
                 if (BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES === True)
                 {
                 echo '<li><span class="bo_descr">'._BL('At').
-             ': </span><a href = "http://maps.google.com/?q= ' . $min_dist_own_lat  .','. $max_dist_own_lon .
+             ': </span><a href = "http://maps.google.com/?q= ' . $max_dist_own_lat  .','. $max_dist_own_lon .
              ' " target="_blank" ><span class="bo_value">'._BN($max_dist_own_lat,3).'&deg; / '._BN($max_dist_own_lon,3).
              '&deg</span> </span><span class="bo_value">(' . ($max_dist_own_time).')</span></a>';
                 }


### PR DESCRIPTION
Updated import.inc.php

Forced bo_update_stations() on first import, otherwise statistics loop has nothing to iterate on.
Added collection and storage of locations and times of nearest and furthest strokes.

Updated default_settings.inc.php

Added new setting BO_STATISTICS_SHOW_LOCATIONS_AND_TIMES_OF_EXTREME_STROKES, default false to control whether this information is displayed

Updated statistics.inc.php

To show the new information when above is set to true in config file.
